### PR TITLE
Added meta no-undo property to prevent specific actions from being undoable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,16 @@ Instead of setting a reducer to be undoable, we'll define which actions are undo
 
 Pros:
 
-1. Easily support multiple changes that should be treated as a single undo step. (animation, drag drop)
-2. We don't need to save the state, instead we save actions which are usually smaller in size
-3. Easily implement "undo actions list" component because we have the list of actions
-4. No change to state structure
+1. Easily support multiple changes that should be treated as a single undo step (animation, drag drop).
+2. We don't need to save the state, instead we save actions which are usually smaller in size.
+3. Easily implement "undo actions list" component because we have the list of actions.
+4. No change to state structure.
+5. Easily prevent certain actions from being added to the undo stack.
 
 Cons:
 
-1. Harder implementation than just applying high-order-reducer
-2. Developers need to be aware they need to provide reverting actions to support undo (or is it a pro?)
+1. Harder implementation than just applying high-order-reducer.
+2. Developers need to be aware they need to provide reverting actions to support undo (or is it a pro?).
 
 ## Usage
 
@@ -67,6 +68,21 @@ If the the original action is not enough to create a reverting action you can pr
 ```
 the `createArgs` function runs before the action happens and collects information needed to revert the action.
 you get this as a second argument for the reverting action creator.
+
+### Make certain actions skip the undo-redo middleware
+Actions with the meta property `noUndo` will be ignored by the middleware whatsoever, even if they have a reverting action:
+```
+dispatch({
+  type: 'SOME_ACTION',
+  payload: {
+    someKey: 'someValue'
+  },
+  meta: {
+    // This will cause the action to not be undoable
+    noUndo: true 
+  }
+})
+```
 
 ### getViewState and setViewState
 this to fields are optional

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const undoMiddleware = createUndoMiddleware({
     'DECREMENT': (action) => increment(),
     'SET_COUNTER_VALUE': {
       action: (action, {oldCounterValue}) => setCounterValue(oldCounterValue),
-      meta: (state, action) => ({oldCounterValue: getCurrentCounterValue(state)})
+      createArgs: (state, action) => ({oldCounterValue: getCurrentCounterValue(state)})
     }
   }
 })
@@ -58,14 +58,14 @@ createUndoMiddleware take a configuration object with the following fields:
 
 ### revertingActions
 This is a map between the `action type` and it's reverting action creator, the action creator gets the original action and should return the reverting action.
-If the the original action is not enough to create a reverting action you can provide an object like this and collect the needed metadata:
+If the the original action is not enough to create a reverting action you can provide `createArgs` that will result in an `args` argument for the reverting action:
 ```js
 {
-  action: (action, meta) => revertingActionCreator(action.something, meta.somethingElse),
-  meta: (state, action) => ({somethingElse: state.something})
+  action: (action, args) => revertingActionCreator(action.something, args.somethingElse),
+  createArgs: (state, action) => ({somethingElse: state.something})
 }
 ```
-the `meta` function runs before the action happens and collects information needed to revert the action.
+the `createArgs` function runs before the action happens and collects information needed to revert the action.
 you get this as a second argument for the reverting action creator.
 
 ### getViewState and setViewState

--- a/src/actions.js
+++ b/src/actions.js
@@ -6,13 +6,13 @@ export function redo() {
   return {type: 'UNDO_HISTORY@REDO'}
 }
 
-export function addUndoItem(action, beforeState, afterState, meta) {
+export function addUndoItem(action, beforeState, afterState, createArgs) {
   return {
     type: 'UNDO_HISTORY@ADD',
     action,
     beforeState,
     afterState,
-    meta
+    createArgs
   }
 }
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -9,10 +9,12 @@ export function redo() {
 export function addUndoItem(action, beforeState, afterState, createArgs) {
   return {
     type: 'UNDO_HISTORY@ADD',
-    action,
-    beforeState,
-    afterState,
-    createArgs
+    payload: {
+      action,
+      beforeState,
+      afterState,
+      createArgs
+    }
   }
 }
 

--- a/src/createUndoMiddleware.js
+++ b/src/createUndoMiddleware.js
@@ -39,7 +39,7 @@ export default function createUndoMiddleware({getViewState, setViewState, revert
           action,
           getViewState && getViewState(state),
           getViewState && getViewState(getState()),
-          getUndoMetadata(state, action)
+          getUndoArgs(state, action)
         ))
       }
       break
@@ -49,17 +49,17 @@ export default function createUndoMiddleware({getViewState, setViewState, revert
   }
 
   function getUndoAction(undoItem) {
-    const {action, meta} = undoItem
+    const {action, args} = undoItem
     const {type} = action
     const actionCreator = get(revertingActions[type], 'action', revertingActions[type])
     if (!actionCreator) {
       throw new Error(`Illegal reverting action definition for '${type}'`)
     }
-    return actionCreator(action, meta)
+    return actionCreator(action, args)
   }
 
-  function getUndoMetadata(state, action) {
-    const metadataFactory = get(revertingActions[action.type], 'meta')
-    return metadataFactory && metadataFactory(state, action)
+  function getUndoArgs(state, action) {
+    const argsFactory = get(revertingActions[action.type], 'createArgs')
+    return argsFactory && argsFactory(state, action)
   }
 }

--- a/src/createUndoMiddleware.js
+++ b/src/createUndoMiddleware.js
@@ -4,7 +4,8 @@ import {getUndoItem, getRedoItem} from './selectors'
 
 export default function createUndoMiddleware({getViewState, setViewState, revertingActions}) {
 
-  const SUPPORTED_ACTIONS = Object.keys(revertingActions)
+  const supportedActions = Object.keys(revertingActions)
+
   let acting = false
 
   return ({dispatch, getState}) => (next) => (action) => {
@@ -17,7 +18,7 @@ export default function createUndoMiddleware({getViewState, setViewState, revert
       if (undoItem) {
         acting = true
         setViewState && dispatch(setViewState(undoItem.afterState))
-        dispatch(getUndoAction(undoItem))
+        dispatch(getUndoAction(undoItem, revertingActions))
         setViewState && dispatch(setViewState(undoItem.beforeState))
         acting = false
       }
@@ -34,12 +35,12 @@ export default function createUndoMiddleware({getViewState, setViewState, revert
     }
       break
     default:
-      if (!acting && includes(SUPPORTED_ACTIONS, action.type)) {
+      if (!acting && canUndoAction(action, supportedActions)) {
         dispatch(addUndoItem(
           action,
           getViewState && getViewState(state),
           getViewState && getViewState(getState()),
-          getUndoArgs(state, action)
+          getUndoArgs(state, action, revertingActions)
         ))
       }
       break
@@ -47,19 +48,27 @@ export default function createUndoMiddleware({getViewState, setViewState, revert
 
     return ret
   }
+}
 
-  function getUndoAction(undoItem) {
-    const {action, args} = undoItem
-    const {type} = action
-    const actionCreator = get(revertingActions[type], 'action', revertingActions[type])
-    if (!actionCreator) {
-      throw new Error(`Illegal reverting action definition for '${type}'`)
-    }
-    return actionCreator(action, args)
+function getUndoAction(undoItem, revertingActions) {
+  const {action, args} = undoItem
+  const {type} = action
+  const actionCreator = get(revertingActions[type], 'action', revertingActions[type])
+  if (!actionCreator) {
+    throw new Error(`Illegal reverting action definition for '${type}'`)
   }
+  return actionCreator(action, args)
+}
 
-  function getUndoArgs(state, action) {
-    const argsFactory = get(revertingActions[action.type], 'createArgs')
-    return argsFactory && argsFactory(state, action)
-  }
+function getUndoArgs(state, action, revertingActions) {
+  const argsFactory = get(revertingActions[action.type], 'createArgs')
+  return argsFactory && argsFactory(state, action)
+}
+
+const NO_UNDO_ACTION_PATH = ['meta', 'noUndo']
+function canUndoAction(action, supportedActions){
+  return (
+    includes(supportedActions, action.type) &&
+    !get(action, NO_UNDO_ACTION_PATH)
+  )
 }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -6,20 +6,20 @@ const INITIAL_UNDO_HISTORY_STATE = {
 }
 
 export default function undoHistoryReducer(state=INITIAL_UNDO_HISTORY_STATE, action) {
-  const {type, ...undoItem} = action
+  const {type, payload: undoItem} = action
   const {undoQueue, redoQueue} = state
 
   switch(type) {
   case 'UNDO_HISTORY@UNDO':
     {
-      return (undoQueue.length == 0) ? state : {
+      return (undoQueue.length === 0) ? state : {
         undoQueue: undoQueue.slice(1),
         redoQueue: [undoQueue[0], ...redoQueue]
       }
     }
   case 'UNDO_HISTORY@REDO':
     {
-      return (redoQueue.length == 0) ? state : {
+      return (redoQueue.length === 0) ? state : {
         undoQueue: [redoQueue[0], ...undoQueue],
         redoQueue: redoQueue.slice(1)
       }

--- a/test/undoMiddleware.js
+++ b/test/undoMiddleware.js
@@ -9,9 +9,14 @@ const initialState = {
 const increment = () => ({type: 'INCREMENT'})
 const decrement = () => ({type: 'DECREMENT'})
 const setCounterVal = (viewState) => ({type: 'SET_COUNTER_VAL', viewState})
+
+const incrementNoUndo = () => ({type: 'INCREMENT', meta: {noUndo: true}})
+
 const notUndoableAction = () => ({type: 'NOT_UNDOABLE'})
+
 const setViewState = viewState => ({type: 'SET_VIEW_STATE', viewState})
 const getViewState = state => state.viewState
+
 const revertingActions = {
   'INCREMENT': () => decrement(),
   'DECREMENT': () => increment(),
@@ -41,6 +46,16 @@ describe('undoMiddleware', function() {
     expect(store.getActions()).to.eql([
       action,
       undoActions.addUndoItem(action, true, true)
+    ])
+  })
+
+  it('doesn\'t dispatch UNDO_HISTORY@ADD for supported actions with "noUndo" meta property', function() {
+    const store = mockStore(initialState)
+    const action = incrementNoUndo()
+    store.dispatch(action)
+
+    expect(store.getActions()).to.eql([
+      action
     ])
   })
 

--- a/test/undoMiddleware.js
+++ b/test/undoMiddleware.js
@@ -17,7 +17,7 @@ const revertingActions = {
   'DECREMENT': () => increment(),
   'SET_COUNTER_VAL': {
     action: (action, {val}) => setCounterVal(val),
-    meta: (state, action) => ({val: state.counter})
+    createArgs: (state, action) => ({val: state.counter})
   }
 }
 const undoMiddleware = createUndoMiddleware({
@@ -54,7 +54,7 @@ describe('undoMiddleware', function() {
     ])
   })
 
-  it('dispatches UNDO_HISTORY@ADD for supported actions with metadata', function() {
+  it('dispatches UNDO_HISTORY@ADD for supported actions with args', function() {
     const store = mockStore(initialState)
     const action = setCounterVal(7)
     store.dispatch(action)
@@ -82,7 +82,7 @@ describe('undoMiddleware', function() {
         counter: 4,
         viewState: true,
         undoHistory: {
-          undoQueue: [{action:increment(), beforeState: undefined, afterState: undefined, meta: undefined}],
+          undoQueue: [{action:increment(), beforeState: undefined, afterState: undefined, args: undefined}],
           redoQueue: []
         }
       })
@@ -99,7 +99,7 @@ describe('undoMiddleware', function() {
         counter: 4,
         viewState: true,
         undoHistory: {
-          undoQueue: [{action:increment(), beforeState: false, afterState: true, meta: undefined}],
+          undoQueue: [{action:increment(), beforeState: false, afterState: true, args: undefined}],
           redoQueue: []
         }
       })
@@ -121,7 +121,7 @@ describe('undoMiddleware', function() {
         viewState: true,
         undoHistory: {
           undoQueue: [],
-          redoQueue: [{action:increment(), beforeState: undefined, afterState: undefined, meta: undefined}]
+          redoQueue: [{action:increment(), beforeState: undefined, afterState: undefined, args: undefined}]
         }
       })
       store.dispatch(undoActions.redo())
@@ -138,7 +138,7 @@ describe('undoMiddleware', function() {
         viewState: true,
         undoHistory: {
           undoQueue: [],
-          redoQueue: [{action:increment(), beforeState: true, afterState: true, meta: undefined}]
+          redoQueue: [{action:increment(), beforeState: true, afterState: true, args: undefined}]
         }
       })
       store.dispatch(undoActions.redo())


### PR DESCRIPTION
This is extremely useful in cases of two actions that are usually undoable happening after each other and many other cases like system firing some action that is unexpected to be undoable.