### PR TITLE
Flux standard action

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ If the the original action is not enough to create a reverting action you can pr
 the `createArgs` function runs before the action happens and collects information needed to revert the action.
 you get this as a second argument for the reverting action creator.
 
+*Note: "createArgs" was "meta" in previous versions of the library and changed to "createArgs" as it is clearer.* 
+
 ### getViewState and setViewState
 this to fields are optional
 `getViewState` is a selector like this: `(state) => derivedState`

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const undoMiddleware = createUndoMiddleware({
     'DECREMENT': (action) => increment(),
     'SET_COUNTER_VALUE': {
       action: (action, {oldCounterValue}) => setCounterValue(oldCounterValue),
-      meta: (state, action) => ({oldCounterValue: getCurrentCounterValue(state)})
+      createArgs: (state, action) => ({oldCounterValue: getCurrentCounterValue(state)})
     }
   }
 })
@@ -58,14 +58,14 @@ createUndoMiddleware take a configuration object with the following fields:
 
 ### revertingActions
 This is a map between the `action type` and it's reverting action creator, the action creator gets the original action and should return the reverting action.
-If the the original action is not enough to create a reverting action you can provide an object like this and collect the needed metadata:
+If the the original action is not enough to create a reverting action you can provide `createArgs` that will result in an `args` argument for the reverting action:
 ```js
 {
-  action: (action, meta) => revertingActionCreator(action.something, meta.somethingElse),
-  meta: (state, action) => ({somethingElse: state.something})
+  action: (action, args) => revertingActionCreator(action.something, args.somethingElse),
+  createArgs: (state, action) => ({somethingElse: state.something})
 }
 ```
-the `meta` function runs before the action happens and collects information needed to revert the action.
+the `createArgs` function runs before the action happens and collects information needed to revert the action.
 you get this as a second argument for the reverting action creator.
 
 ### getViewState and setViewState

--- a/src/actions.js
+++ b/src/actions.js
@@ -6,13 +6,13 @@ export function redo() {
   return {type: 'UNDO_HISTORY@REDO'}
 }
 
-export function addUndoItem(action, beforeState, afterState, meta) {
+export function addUndoItem(action, beforeState, afterState, createArgs) {
   return {
     type: 'UNDO_HISTORY@ADD',
     action,
     beforeState,
     afterState,
-    meta
+    createArgs
   }
 }
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -6,13 +6,15 @@ export function redo() {
   return {type: 'UNDO_HISTORY@REDO'}
 }
 
-export function addUndoItem(action, beforeState, afterState, createArgs) {
+export function addUndoItem(action, beforeState, afterState, args) {
   return {
     type: 'UNDO_HISTORY@ADD',
-    action,
-    beforeState,
-    afterState,
-    createArgs
+    payload: {
+      action,
+      beforeState,
+      afterState,
+      args
+    }
   }
 }
 

--- a/src/createUndoMiddleware.js
+++ b/src/createUndoMiddleware.js
@@ -39,7 +39,7 @@ export default function createUndoMiddleware({getViewState, setViewState, revert
           action,
           getViewState && getViewState(state),
           getViewState && getViewState(getState()),
-          getUndoMetadata(state, action)
+          getUndoArgs(state, action)
         ))
       }
       break
@@ -49,17 +49,17 @@ export default function createUndoMiddleware({getViewState, setViewState, revert
   }
 
   function getUndoAction(undoItem) {
-    const {action, meta} = undoItem
+    const {action, args} = undoItem
     const {type} = action
     const actionCreator = get(revertingActions[type], 'action', revertingActions[type])
     if (!actionCreator) {
       throw new Error(`Illegal reverting action definition for '${type}'`)
     }
-    return actionCreator(action, meta)
+    return actionCreator(action, args)
   }
 
-  function getUndoMetadata(state, action) {
-    const metadataFactory = get(revertingActions[action.type], 'meta')
-    return metadataFactory && metadataFactory(state, action)
+  function getUndoArgs(state, action) {
+    const argsFactory = get(revertingActions[action.type], 'createArgs')
+    return argsFactory && argsFactory(state, action)
   }
 }

--- a/src/createUndoMiddleware.js
+++ b/src/createUndoMiddleware.js
@@ -4,6 +4,10 @@ import {getUndoItem, getRedoItem} from './selectors'
 
 export default function createUndoMiddleware({getViewState, setViewState, revertingActions}) {
 
+  if(Object.values(revertingActions).some(revertingAction => revertingAction.meta)){
+    console.warn('[redux-undo-redo] The "meta" property in reverting actions is deprecated and replaced with "createArgs" and will be removed in future versions.')
+  }
+
   const SUPPORTED_ACTIONS = Object.keys(revertingActions)
   let acting = false
 
@@ -59,7 +63,12 @@ export default function createUndoMiddleware({getViewState, setViewState, revert
   }
 
   function getUndoArgs(state, action) {
-    const argsFactory = get(revertingActions[action.type], 'createArgs')
+    let argsFactory = get(revertingActions[action.type], 'createArgs')
+
+    if(!argsFactory){
+      argsFactory = get(revertingActions[action.type], 'meta')
+    }
+
     return argsFactory && argsFactory(state, action)
   }
 }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -6,20 +6,20 @@ const INITIAL_UNDO_HISTORY_STATE = {
 }
 
 export default function undoHistoryReducer(state=INITIAL_UNDO_HISTORY_STATE, action) {
-  const {type, ...undoItem} = action
+  const {type, payload: undoItem} = action
   const {undoQueue, redoQueue} = state
 
   switch(type) {
   case 'UNDO_HISTORY@UNDO':
     {
-      return (undoQueue.length == 0) ? state : {
+      return (undoQueue.length === 0) ? state : {
         undoQueue: undoQueue.slice(1),
         redoQueue: [undoQueue[0], ...redoQueue]
       }
     }
   case 'UNDO_HISTORY@REDO':
     {
-      return (redoQueue.length == 0) ? state : {
+      return (redoQueue.length === 0) ? state : {
         undoQueue: [redoQueue[0], ...undoQueue],
         redoQueue: redoQueue.slice(1)
       }

--- a/test/undoMiddleware.js
+++ b/test/undoMiddleware.js
@@ -65,6 +65,32 @@ describe('undoMiddleware', function() {
     ])
   })
 
+  it('dispatches UNDO_HISTORY@ADD for supported actions with args using the deprecated "meta" property', function() {
+    const deprecatedRevertingActions = {
+      'INCREMENT': () => decrement(),
+      'DECREMENT': () => increment(),
+      'SET_COUNTER_VAL': {
+        action: (action, {val}) => setCounterVal(val),
+        meta: (state, action) => ({val: state.counter})
+      }
+    }
+    const undoMiddleware = createUndoMiddleware({
+      getViewState,
+      setViewState,
+      revertingActions: deprecatedRevertingActions
+    })
+    const mockStore = configureStore([undoMiddleware])
+
+    const store = mockStore(initialState)
+    const action = setCounterVal(7)
+    store.dispatch(action)
+
+    expect(store.getActions()).to.eql([
+      action,
+      undoActions.addUndoItem(action, true, true, {val: initialState.counter})
+    ])
+  })
+
   it('dispatches UNDO_HISTORY@ADD with view states', function() {
     const store = mockStore(initialState)
     const action = setCounterVal(7)

--- a/test/undoMiddleware.js
+++ b/test/undoMiddleware.js
@@ -17,7 +17,7 @@ const revertingActions = {
   'DECREMENT': () => increment(),
   'SET_COUNTER_VAL': {
     action: (action, {val}) => setCounterVal(val),
-    meta: (state, action) => ({val: state.counter})
+    createArgs: (state, action) => ({val: state.counter})
   }
 }
 const undoMiddleware = createUndoMiddleware({
@@ -54,7 +54,7 @@ describe('undoMiddleware', function() {
     ])
   })
 
-  it('dispatches UNDO_HISTORY@ADD for supported actions with metadata', function() {
+  it('dispatches UNDO_HISTORY@ADD for supported actions with args', function() {
     const store = mockStore(initialState)
     const action = setCounterVal(7)
     store.dispatch(action)
@@ -82,7 +82,7 @@ describe('undoMiddleware', function() {
         counter: 4,
         viewState: true,
         undoHistory: {
-          undoQueue: [{action:increment(), beforeState: undefined, afterState: undefined, meta: undefined}],
+          undoQueue: [{action:increment(), beforeState: undefined, afterState: undefined, args: undefined}],
           redoQueue: []
         }
       })
@@ -99,7 +99,7 @@ describe('undoMiddleware', function() {
         counter: 4,
         viewState: true,
         undoHistory: {
-          undoQueue: [{action:increment(), beforeState: false, afterState: true, meta: undefined}],
+          undoQueue: [{action:increment(), beforeState: false, afterState: true, args: undefined}],
           redoQueue: []
         }
       })
@@ -121,7 +121,7 @@ describe('undoMiddleware', function() {
         viewState: true,
         undoHistory: {
           undoQueue: [],
-          redoQueue: [{action:increment(), beforeState: undefined, afterState: undefined, meta: undefined}]
+          redoQueue: [{action:increment(), beforeState: undefined, afterState: undefined, args: undefined}]
         }
       })
       store.dispatch(undoActions.redo())
@@ -138,7 +138,7 @@ describe('undoMiddleware', function() {
         viewState: true,
         undoHistory: {
           undoQueue: [],
-          redoQueue: [{action:increment(), beforeState: true, afterState: true, meta: undefined}]
+          redoQueue: [{action:increment(), beforeState: true, afterState: true, args: undefined}]
         }
       })
       store.dispatch(undoActions.redo())


### PR DESCRIPTION
changed the ambiguous "meta" property name to a clearer property name.

meta is confusing because it's hard to tell from the name what's its purpose.